### PR TITLE
Remove `id` type, which will not be required by `mirage-types` 3.

### DIFF
--- a/lib/vnetif.ml
+++ b/lib/vnetif.ml
@@ -54,9 +54,6 @@ module Make (B : BACKEND) = struct
     stats : stats;
   }
 
-  let id t =
-    t.id
-
   let connect backend = 
       match (B.register backend) with
       | `Error _ -> Lwt.fail_with "vnetif: error while registering to backend"

--- a/lib/vnetif.mli
+++ b/lib/vnetif.mli
@@ -39,7 +39,6 @@ module Make(B : BACKEND) : sig
     with type 'a io = 'a Lwt.t
      and type     page_aligned_buffer = Io_page.t
      and type     buffer = Cstruct.t
-     and type     id = B.id
      and type     macaddr = Macaddr.t
 
     val connect : B.t -> t io


### PR DESCRIPTION
A corresponding PR to the `mirage` repository will be made shortly.  Feel free to merge this before that PR is merged, but if you do so `mirage-vnetif` will briefly not be buildable.
