### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-vnetif.opam
+++ b/mirage-vnetif.opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune"  {build & >= "1.0"}
+  "dune"  {>= "1.0"}
   "lwt"
   "mirage-time-lwt" {>= "1.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.