### PR TITLE
adapt to mirage-net 3.0.0 changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ script: bash -ex ./.travis-docker.sh
 env:
   global:
   - PACKAGE="mirage-vnetif"
-  - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
   matrix:
-  - DISTRO="debian-testing" OCAML_VERSION="4.04"
-  - DISTRO="debian-unstable" OCAML_VERSION="4.05"
-  - DISTRO="ubuntu-16.04" OCAML_VERSION="4.06"
-  - DISTRO="alpine" OCAML_VERSION="4.07"
+  - DISTRO="debian-testing" OCAML_VERSION="4.09"
+  - DISTRO="debian-unstable" OCAML_VERSION="4.08"
+  - DISTRO="ubuntu-16.04" OCAML_VERSION="4.07"
+  - DISTRO="alpine" OCAML_VERSION="4.06"

--- a/mirage-vnetif.opam
+++ b/mirage-vnetif.opam
@@ -14,12 +14,12 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.06.0"}
   "dune"  {>= "1.0"}
   "lwt"
-  "mirage-time-lwt" {>= "1.0.0"}
-  "mirage-clock-lwt" {>= "1.2.0"}
-  "mirage-net-lwt" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-net" {>= "3.0.0"}
   "cstruct" {>="2.4.0"}
   "ipaddr" {>= "3.0.0"}
   "macaddr"

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -1,3 +1,0 @@
-#!/usr/bin/env ocaml
-#use "topfind"
-#require "topkg-jbuilder.auto"

--- a/src/dune
+++ b/src/dune
@@ -3,5 +3,5 @@
  (public_name mirage-vnetif)
  (modules basic_backend vnetif)
  (wrapped false)
- (libraries cstruct lwt mirage-clock-lwt ipaddr macaddr mirage-profile
-   duration result mirage-time-lwt mirage-net mirage-net-lwt logs))
+ (libraries cstruct lwt mirage-clock ipaddr macaddr mirage-profile
+   duration result mirage-time mirage-net logs))

--- a/src/vnetif.ml
+++ b/src/vnetif.ml
@@ -36,11 +36,8 @@ module type BACKEND = sig
 end
 
 module Make (B : BACKEND) = struct
-  type buffer = B.buffer
   type error = Net.error
   let pp_error = Mirage_net.Net.pp_error
-  type macaddr = B.macaddr
-  type +'a io = 'a Lwt.t
 
   type t = {
     id : B.id;

--- a/src/vnetif.mli
+++ b/src/vnetif.mli
@@ -35,6 +35,6 @@ end
 
 (** Dummy interface for software bridge. *)
 module Make(B : BACKEND) : sig
-  include Mirage_net_lwt.S
+  include Mirage_net.S
   val connect : ?size_limit:int -> B.t -> t Lwt.t
 end


### PR DESCRIPTION
- mirage-net-lwt is retired
- mirage-net is specialised to Lwt.t / Cstruct.t / Macaddr.t
- lower OCaml bound is 4.06.0