### PR TITLE
use less type aliases (io is Lwt.t, buffer is Cstruct.t)

### DIFF
--- a/src/vnetif-stack/vnetif_stack.ml
+++ b/src/vnetif-stack/vnetif_stack.ml
@@ -19,15 +19,12 @@ open Lwt.Infix
 module type Vnetif_stack =
 sig
   type backend
-  type buffer
-  type 'a io
-  type id
   module V4V6 : Tcpip.Stack.V4V6
   module Backend : Vnetif.BACKEND
 
   (** Create a new IPv4 stack connected to an existing backend *)
   val create_stack_ipv4 : cidr:Ipaddr.V4.Prefix.t ->
-    ?gateway:Ipaddr.V4.t -> ?mtu:int -> ?monitor_fn:(buffer -> unit io) ->
+    ?gateway:Ipaddr.V4.t -> ?mtu:int -> ?monitor_fn:(Cstruct.t -> unit Lwt.t) ->
     ?unlock_on_listen:Lwt_mutex.t ->
     backend -> V4V6.t Lwt.t
 end
@@ -36,9 +33,6 @@ module Vnetif_stack (B : Vnetif.BACKEND)(R : Mirage_random.S)(Time : Mirage_time
           Vnetif_stack with type backend = B.t =
 struct
   type backend = B.t
-  type buffer = B.buffer
-  type 'a io = 'a B.io
-  type id = B.id
 
   module Backend = B
   module V = Vnetif.Make(Backend)

--- a/src/vnetif/vnetif.mli
+++ b/src/vnetif/vnetif.mli
@@ -18,24 +18,20 @@
 open Mirage_net
 
 module type BACKEND = sig
-  type 'a io = 'a Lwt.t
-  type buffer = Cstruct.t
-  type id = int
-  type macaddr = Macaddr.t
   type t
 
-  val register : t -> (id, Net.error) result
-  val unregister : t -> id -> unit io
-  val mac : t -> id -> macaddr
-  val write : t -> id -> size:int -> (buffer -> int) -> (unit, Net.error) result io
-  val set_listen_fn : t -> id -> (buffer -> unit io) -> unit
-  val unregister_and_flush : t -> id -> unit io
+  val register : t -> (int, Net.error) result
+  val unregister : t -> int -> unit Lwt.t
+  val mac : t -> int -> Macaddr.t
+  val write : t -> int -> size:int -> (Cstruct.t -> int) -> (unit, Net.error) result Lwt.t
+  val set_listen_fn : t -> int -> (Cstruct.t -> unit Lwt.t) -> unit
+  val unregister_and_flush : t -> int -> unit Lwt.t
 end
 
 
 (** Dummy interface for software bridge. *)
 module Make(B : BACKEND) : sig
   include Mirage_net.S
-  val connect : ?size_limit:int -> ?flush_on_disconnect:bool -> ?monitor_fn:(B.buffer -> unit Lwt.t) -> ?unlock_on_listen:Lwt_mutex.t -> B.t -> t Lwt.t
+  val connect : ?size_limit:int -> ?flush_on_disconnect:bool -> ?monitor_fn:(Cstruct.t -> unit Lwt.t) -> ?unlock_on_listen:Lwt_mutex.t -> B.t -> t Lwt.t
   val disconnect : t -> unit Lwt.t
 end


### PR DESCRIPTION
less is more, but less is also easier to comprehend